### PR TITLE
Log bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-test-adapter-util",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A collection of utility functions for use in test adapters for the VS Code test explorer",
   "author": "Holger Benl <hbenl@evandor.de>",
   "license": "MIT",


### PR DESCRIPTION
The following situation could happen:
- quicly calling a couple of `write` before the `fs.open`'s callback actually called (filling the buffer)
- after the `fs.open`'s callback arrived: calling a `write`
- before the `fs.write`'s callback arrived: calling `dispose` would close the descriptor
- a previously called `fs.write`'s callback could arrive and tried to write more but the descriptor has been closed already