### PR TITLE
Log bug fix fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-test-adapter-util",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A collection of utility functions for use in test adapters for the VS Code test explorer",
   "author": "Holger Benl <hbenl@evandor.de>",
   "license": "MIT",

--- a/src/log.ts
+++ b/src/log.ts
@@ -166,8 +166,7 @@ export class FileTarget implements ILogTarget {
 	}
 
 	write(msg: string): void {
-		this.writeStream.write(msg);
-		this.writeStream.write('\n');
+		this.writeStream.write(msg + '\n');
 	}
 
 	dispose(): void {


### PR DESCRIPTION
Just noticed that it can happen (rarely) that the `WriteStream.write`s aren't sequential.
I'm not sure that it is a nodejs bug or not, but this commit (almost) solves the problem.

!! Remark !!: I assume it still can happen that lines are swapped.
It doesn't seem a big problem for me. Agree?