### PR TITLE
Log bug fix fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-test-adapter-util",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A collection of utility functions for use in test adapters for the VS Code test explorer",
   "author": "Holger Benl <hbenl@evandor.de>",
   "license": "MIT",

--- a/src/log.ts
+++ b/src/log.ts
@@ -155,7 +155,6 @@ export class OutputChannelTarget implements ILogTarget {
 
 export class FileTarget implements ILogTarget {
 
-	private readonly buffered: string[] = [];
 	private readonly writeStream: fs.WriteStream;
 
 	constructor(filename: string) {
@@ -166,8 +165,7 @@ export class FileTarget implements ILogTarget {
 	}
 
 	write(msg: string): void {
-		this.writeStream.write(msg);
-		this.writeStream.write('\n');
+		this.writeStream.write(msg + '\n');
 	}
 
 	dispose(): void {


### PR DESCRIPTION
From the previous pull request.
> Just noticed that it can happen (rarely) that the `WriteStream.write`s aren't sequential.
> I'm not sure that it is a nodejs bug or not, but this commit (almost) solves the problem.
> Remark: I assume it still can happen that lines are swapped.

I canceled the previous pull request because I thought this is not good enough solution: 

> If a call to stream.write(chunk) returns false, the 'drain' event will be emitted when it is appropriate to resume writing data to the stream.

from [here](https://nodejs.org/api/stream.html#stream_event_drain).

But [this guy](https://stackoverflow.com/questions/19051510/node-js-writing-data-to-the-writable-stream) says what I originally thought: `Even if the "write" method returns false you can still call subsequent writes and node will buffer the pending write requests into memory.`

And also this:

>While a stream is not draining, calls to write() will buffer chunk, and return false.

from [here](https://nodejs.org/api/stream.html#stream_event_drain).

So I guess it's ok and it looks it solves the issue.
The only thing is that I don't get it why..